### PR TITLE
English expression instead of index

### DIFF
--- a/app/application/views/projects/index.php
+++ b/app/application/views/projects/index.php
@@ -37,7 +37,7 @@
 					<li>
 						<a href="<?php echo $row->to(); ?>"><?php echo $row->name; ?></a><br />
 						<?php echo $issues == 1 ? '1 '. __('tinyissue.open_issue') : $issues . ' '. __('tinyissue.open_issues'); ?><br/>
-						<strong><?php echo (__('tinyissue.velocity_velocity') == 'tinyissue.velocity_velocity') ? 'Velocity' :  __('tinyissue.velocity_velocity'); ?>:</strong>&nbsp;<?php echo $velocity.'&nbsp;'.((__('tinyissue.velocity_rate') == 'tinyissue.velocity_rate') ? 'issues/per day' :  __('tinyissue.velocity_rate')); ?>&nbsp;&nbsp;&nbsp;<strong><?php echo (__('tinyissue.velocity_etc') == 'tinyissue.velocity_etc') ? 'ETC' :  __('tinyissue.velocity_etc'); ?>:</strong>&nbsp;<?php echo $etc; ?>
+						<strong><?php echo __('tinyissue.velocity_velocity'); ?>:</strong>&nbsp;<?php echo $velocity.'&nbsp;'.__('tinyissue.velocity_rate'); ?>&nbsp;&nbsp;&nbsp;<strong><?php echo __('tinyissue.velocity_etc'); ?>:</strong>&nbsp;<?php echo $etc; ?>
 					</li>
 					<?php endforeach; ?>
 

--- a/app/laravel/lang.php
+++ b/app/laravel/lang.php
@@ -76,7 +76,6 @@ class Lang {
 	public static function line($key, $replacements = array(), $language = null)
 	{
 		if (is_null($language)) $language = Config::get('application.language');
-
 		return new static($key, $replacements, $language);
 	}
 
@@ -112,10 +111,11 @@ class Lang {
 	 */
 	public function get($language = null, $default = null)
 	{
+		global $LangEN;
 		// If no default value is specified by the developer, we'll just return the
 		// key of the language line. This should indicate which language line we
 		// were attempting to render and is better than giving nothing back.
-		if (is_null($default)) $default = $this->key;
+		if (is_null($default)) $default = $LangEN["tinyissue"][substr($this->key, strrpos($this->key, ".")+1)] ?? $this->key;
 
 		if (is_null($language)) $language = $this->language;
 
@@ -132,6 +132,7 @@ class Lang {
 		$lines = static::$lines[$bundle][$language][$file];
 
 		$line = array_get($lines, $line, $default);
+		if ($line == $this->key) { echo 'Merdus crocus'; }
 
 		// If the line is not a string, it probably means the developer asked for
 		// the entire language file and the value of the requested value will be

--- a/index.php
+++ b/index.php
@@ -9,10 +9,12 @@ if(!file_exists(__DIR__ . '/config.app.php'))
 
 define('LARAVEL_START', microtime(true));
 $web = true;
+$LangEN = array();
+$LangEN["pagination"] = require 'app/application/language/en/pagination.php';
+$LangEN["tinyissue"] = require 'app/application/language/en/tinyissue.php';
+$LangEN["validation"] = require 'app/application/language/en/validation.php';
+
 require 'app/paths.php';
 unset($web);
 
 require path('sys').'laravel.php';
-
-?>
-


### PR DESCRIPTION
When an expression was not defined in your language, the « bugs » program returned its index value like « tinyissue.welcome ».
Instead of that index value, you'll now find the english expression as default.
That means, you'll read  « Welcome ».
As soon as you'll define a valuable text for such index in your own language file, such text will show up.
For example: in french the value for tinyissue.welcome is « Bienvenue »
« Bienvenue » shows up when you use french language in Bugs program.