### PR TITLE
Working on next release which will include auto-update

### DIFF
--- a/app/application/views/administration/index.php
+++ b/app/application/views/administration/index.php
@@ -35,8 +35,8 @@
 		<tr>
 			<th>Tiny Issue <?php echo __('tinyissue.version'); ?></th>
 			<td><?php
-//					$project_status = \DB::table('update_history')->where('Description', 'LIKE', 'Version%')->order_by('DteRelease','DESC')->get();
-//					echo $project_status[0]->description;
+					$project_status = \DB::table('update_history')->where('Description', 'LIKE', 'Version%')->order_by('DteRelease','DESC')->get();
+					echo $project_status[0]->description;
 				?>
 			</td>
 			<td rowspan="2" style="min-width: 150px; padding-left: 100px;"><br /><?php echo __('tinyissue.let_update_it'); ?></td>

--- a/install/update_v1-6_0.sql
+++ b/install/update_v1-6_0.sql
@@ -1,0 +1,13 @@
+# Update from 1-3.2 to 1-6.0
+
+CREATE TABLE  IF NOT EXISTS `update_history` (
+  `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `Description` varchar(100) NULL,
+  `Footprint` varchar(25) NULL,
+  `DteRelease` datetime NULL,
+  `DteInstall` datetime NULL
+);
+
+INSERT IGNORE INTO `update_history` (`Footprint`, `Description`, `DteRelease`, `DteInstall`)
+VALUES ('------------------------------', 'Version 1.6.0', '2017-05-01', NULL);
+

--- a/install/updates_status.txt
+++ b/install/updates_status.txt
@@ -1,0 +1,1 @@
+62e7709 - Proper version number and release date (2017-04-09 20:34:24 -0400)

--- a/updates_status.txt
+++ b/updates_status.txt
@@ -1,0 +1,1 @@
+f752f3a - MySQL file should not make mistake (ver 1c) (2017-04-10 21:14:24 -0400)


### PR DESCRIPTION
Next branches' names will follow the release numbers, except for some special uses like « Encryptage » which is for and PHP update from 5.4 to 7.1
Other way, whatever linked to changing to code, adding function will be in the « Release_xyz » branch until this release become the master.