### PR TITLE
fix scandir() sorting parameter work with php-5.3.x

### DIFF
--- a/app/application/views/administration/users/add.php
+++ b/app/application/views/administration/users/add.php
@@ -45,8 +45,8 @@
 					<select name="language">
 					<?php
 						//Language has added in nov 2016
-						$Lng = scandir("application/language/", SCANDIR_SORT_ASCENDING);
-						$Not = array(".", "..");
+						$Lng = scandir("application/language/");
+						$Not = array(".", "..", "all.php");
 						foreach ($Lng as $val) { if(!in_array($val, $Not)) { echo '<option value="'.$val.'" '; if ($val == Auth::user()->language) { echo ' selected="selected" '; } echo '>'.$val.'</option>'; } }
 					?>
 					</select>

--- a/app/application/views/administration/users/edit.php
+++ b/app/application/views/administration/users/edit.php
@@ -40,8 +40,8 @@
 					<select name="language">
 					<?php
 						//Language has added in nov 2016
-						$Lng = scandir("application/language/", SCANDIR_SORT_ASCENDING);
-						$Not = array(".", "..");
+						$Lng = scandir("application/language/");
+						$Not = array(".", "..", "all.php");
 						foreach ($Lng as $val) { if(!in_array($val, $Not)) { echo '<option value="'.$val.'" '; if ($val == Input::old('language',$user->language)) { echo ' selected="selected" '; } echo '>'.$val.'</option>'; } }
 					?>
 					</select>


### PR DESCRIPTION
Simple and Neat! Great works.

Anyway, Now I'm in translation with Japanese, and before that, fix 2.

1. scandir() parameter "SCANDIR_SORT_ASCENDING" constants seems not works PHP-5.3.X, but works since PHP-5.4.0. 

http://php.net/manual/en/function.scandir.php
http://php.net/manual/en/dir.constants.php

I'm using CentOS 6.9+PHP-5.3.3-49, following error ocurrs,

```
Unhandled Exception

Message:

Error rendering view: [administration.users.add]

Use of undefined constant SCANDIR_SORT_ASCENDING - assumed 'SCANDIR_SORT_ASCENDING'
Location:

/var/www/html/app/application/views/administration/users/add.php on line 48
Stack Trace:

#0 /var/www/html/app/laravel/laravel.php(42): Laravel\Error::native(8, 'Use of undefine...', '/var/www/html/a...', 48)
#1 /var/www/html/app/laravel/view.php(376) : eval()'d code(48): Laravel\{closure}(8, 'Use of undefine...', '/var/www/html/a...', 48, Array)
#2 /var/www/html/app/laravel/view.php(376): eval()
#3 /var/www/html/app/laravel/view.php(344): Laravel\View->get()
#4 /var/www/html/app/laravel/view.php(438): Laravel\View->render()
#5 /var/www/html/app/laravel/view.php(363): Laravel\View->data()
#6 /var/www/html/app/laravel/view.php(344): Laravel\View->get()
#7 /var/www/html/app/laravel/view.php(581): Laravel\View->render()
#8 /var/www/html/app/laravel/response.php(246): Laravel\View->__toString()
#9 /var/www/html/app/laravel/laravel.php(177): Laravel\Response->render()
#10 /var/www/html/index.php(19): require('/var/www/html/a...')
#11 {main}
```

Requirements says "PHP 5.3+", however this feature will not be backported to PHP-5.3 on CentOS/RHEL anymore. So, you have choices. This is always difficult....

2. /administration/users/add shows user's languages, and it lists "all.php", too. Fixed this.