### PR TITLE
Makes the HTML mailing to work

### DIFF
--- a/app/application/libraries/mail.php
+++ b/app/application/libraries/mail.php
@@ -15,19 +15,6 @@ class Mail {
 		$mail = new PHPMailer();
 		$mail->Mailer = $options['transport'];
 		switch ($options['transport']) {
-			case 'smtp':												//If you correct the smtp part, please correct ALSO the default part
-				require_once  path('app') .  'libraries/PHPmailer/class.smtp.php';
-				$mail->SMTPDebug = 0;								// 0 = no output, 1 = errors and messages, 2 = messages only.
-				if ($options['smtp']['encryption'] == '') {
-				} else {
-					$mail->SMTPAuth = true;							// enable SMTP authentication
-					$mail->SMTPSecure = $options['smtp']['encryption'];	// sets the prefix to the server
-					$mail->Host = $options['smtp']['server'];
-					$mail->Port = $options['smtp']['port'];
-					$mail->Username = $options['smtp']['username'];
-					$mail->Password = $options['smtp']['password'];
-				}
-				break;
 			case 'mail':
 				//Please submit your code
 				//On March 14th, 2017 I had no time to go further on this
@@ -36,28 +23,35 @@ class Mail {
 				//Please submit your code
 				//On March 14th, 2017 I had no time to go further on this
 				break;
-			default:															//If you correct the default part, please correct ALSO the smtp part
+			default:																		//Which ever configuration you've chosen different from 'mail' and 'sendmail'
+																							//This part is used for the 'smtp' (default) value also
 				require_once path('app') .  'libraries/PHPmailer/class.smtp.php';
-				$mail->SMTPDebug = 1;									// 0 = no output, 1 = errors and messages, 2 = messages only.
+				$mail->SMTPDebug = 1;												// 0 = no output, 1 = errors and messages, 2 = messages only.
 				if ($options['smtp']['encryption'] == '') {
 				} else {
-					$mail->SMTPAuth = true;								// enable SMTP authentication
+					$mail->SMTPAuth = true;											// enable SMTP authentication
 					$mail->SMTPSecure = $options['smtp']['encryption'];	// sets the prefix to the server
 					$mail->Host = $options['smtp']['server'];
 					$mail->Port = $options['smtp']['port'];
 					$mail->Username = $options['smtp']['username'];
 					$mail->Password = $options['smtp']['password'];
 				}
-				break;
 		}
 
 		$mail->CharSet = (isset($options['encoding'])) ? $options['encoding'] : 'windows-1250';
 		$mail->SetFrom ($options['from']['email'], $options['from']['name']);
 		$mail->Subject = $subject;
-		$mail->ContentType = 'text/plain';
-		$mail->IsHTML(false);
+		$mail->ContentType = (isset($option['plainHTML'])) ? $option['plainHTML'] : 'text/plain';
+		if ($mail->ContentType == 'html') {
+			$mail->IsHTML(true);
+			$mail->WordWrap = ($options[isset('linelenght'])) ? $options['linelenght'] : 80;
+			$mail->Body    = $message;
+			$mail->AltBody = strip_tags($message);
+		} else {
+			$mail->IsHTML(false);
+			$mail->Body = strip_tags($message);
+		}
 
-		$mail->Body = $message;
 		$mail->AddAddress ($to);
 
 		$result = $mail->Send() ? "Successfully sent!" : "Mailer Error: " . $mail->ErrorInfo;

--- a/config.app.example.php
+++ b/config.app.example.php
@@ -76,7 +76,14 @@ return array(
 			'username' => 'xyzxyz',
 			'password' => '******'
 		),
-		'encoding' => 'UTF-8'
+		'encoding' => 'UTF-8',
+		/*
+		* Final delivery format
+		* Default: text/plain
+		* 'text/plain' or 'html'  must be lower case
+		*/
+		'plainHTML' => 'text/plain',
+		'linelenght' => 80
 	),
 
 	/**  Timezone


### PR DESCRIPTION
New sub-branch for work, when it will be good enough, we'll merge to master
This commit updates the mail.php files.
You'll need to add those lines to your already existing config.app.php file
		/*
		* Final delivery format
		* Default: text/plain
		* 'text/plain' or 'html'  must be lower case
		*/
		'plainHTML' => 'text/plain',
		'linelenght' => 80

Don't forget the comma at the end of the 'encoding' line  (line 79) like:
		'encoding' => 'UTF-8'**,**
