### PR TITLE
Déboguage de ftcolor dans les tags

### DIFF
--- a/app/application/language/en/tinyissue.php
+++ b/app/application/language/en/tinyissue.php
@@ -261,7 +261,7 @@ return array(
 	'tag' => 'Tag',
 	'tags_added' => 'tags added',
 	'tags_bgcolor' => 'Background',
-	'tags_ftcolor' => 'Font color',
+	'tags_ftcolor' => 'Font color for tag',
 	'tags_removed' => 'tags removed',
 	'tags' => 'Tags',
 	'thisproject_details' => 'This project specs',

--- a/app/application/language/fr/tinyissue.php
+++ b/app/application/language/fr/tinyissue.php
@@ -261,7 +261,7 @@ return array(
 	'tag' => 'Étiquette',
 	'tags_added' => 'étiquettes ajoutées',
 	'tags_bgcolor' => 'Couleur de fond',
-	'tags_ftcolor' => 'Couleur de police',
+	'tags_ftcolor' => 'Couleur de police de ceci',
 	'tags_removed' => 'étiquettes retirées',
 	'tags' => 'Étiquettes',
 	'thisproject_members' => 'Détails du projet',

--- a/app/application/views/activity/update-issue-tags.php
+++ b/app/application/views/activity/update-issue-tags.php
@@ -8,7 +8,11 @@
 		<div class="tag-activity">
 			<?php if($tag_counts['added'] > 0): ?>
 			<?php foreach($tag_diff['added_tags'] as $tag): ?>
-				<?php echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="color: '.$tag_diff['tag_data'][$tag]['ftcolor'].'; background-color: '.$tag_diff['tag_data'][$tag]['bgcolor'].';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; ?>
+				<?php 
+						//2 sept 2021 recherche d'un bogue lié à ftcolor
+				//echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="color: '.$tag_diff['tag_data'][$tag]['ftcolor'].'; background-color: '.$tag_diff['tag_data'][$tag]['bgcolor'].';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+				echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="background-color: '.$tag_diff['tag_data'][$tag]['bgcolor'].';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+				?>
 			<?php endforeach; ?>
 			<?php echo __($tag_counts['added'] > 1 ? 'tinyissue.tags_added' : 'tinyissue.tag_added'); ?>
 			<?php echo __('tinyissue.in'); ?>
@@ -21,7 +25,11 @@
 
 			<?php if($tag_counts['removed'] > 0): ?>
 			<?php foreach($tag_diff['removed_tags'] as $tag): ?>
-				<?php echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="float: none; color: ' . $tag_diff['tag_data'][$tag]['ftcolor'] . '; background-color: ' . $tag_diff['tag_data'][$tag]['bgcolor'] . ';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; ?>
+				<?php 
+					//2 sept 2021 recherche d'un bogue lié à ftcolor
+					//echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="float: none; color: ' . $tag_diff['tag_data'][$tag]['ftcolor'] . '; background-color: ' . $tag_diff['tag_data'][$tag]['bgcolor'] . ';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+					echo '<label class="label"' . (isset($tag_diff['tag_data'][$tag]['bgcolor']) ? ' style="float: none; background-color: ' . $tag_diff['tag_data'][$tag]['bgcolor'] . ';"' : '') . '>' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+				?>
 			<?php endforeach; ?>
 			<?php echo __($tag_counts['removed'] > 1 ? 'tinyissue.tags_removed' : 'tinyissue.tag_removed'); ?>
 			<?php echo __('tinyissue.in'); ?>

--- a/app/application/views/project/index/issues.php
+++ b/app/application/views/project/index/issues.php
@@ -76,7 +76,9 @@ if (!Project\User::MbrProj(\Auth::user()->id, Project::current()->id)) {
 				if(!empty($row->tags)) {
 					echo '<div class="tags">';
 					foreach($row->tags()->order_by('tag', 'ASC')->get() as $tag) {
-						echo '<label class="label" style="'.($tag->bgcolor ? ' background-color: ' . $tag->bgcolor . ';' : '').($tag->ftcolor ? ' color: ' . $tag->ftcolor . ';' : '').'">' . $tag->tag . '</label>';
+						//2 sept 2021 recherche d'un bogue lié à ftcolor
+						//echo '<label class="label" style="'.($tag->bgcolor ? ' background-color: ' . $tag->bgcolor . ';' : '').($tag->ftcolor ? ' color: ' . $tag->ftcolor . ';' : '').'">' . $tag->tag . '</label>';
+						echo '<label class="label" style="'.($tag->bgcolor ? ' background-color: ' . $tag->bgcolor . ';' : '').'">' . $tag->tag . '</label>';
 					}
 					echo '</div>';
 				} 

--- a/app/application/views/project/issue/activity/update-issue-tags.php
+++ b/app/application/views/project/issue/activity/update-issue-tags.php
@@ -24,13 +24,17 @@
 						echo count($j['added_tags']).' '.((count($j['added_tags']) > 1) ? __('tinyissue.tags_added') : __('tinyissue.tag_added')).'.';
 						foreach ($j['tag_data'] as $ind => $val ) { 
 							$tag_info = \DB::table('tags')->where('id', '=', $val["id"])->get();
-							if ( in_array($val['id'], $j['added_tags'])) { echo '<label style="background-color: '.$tag_info[0]->bgcolor.'; color: '.$tag_info[0]->ftcolor.'; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
+						//2 sept 2021 recherche d'un bogue lié à ftcolor
+//							if ( in_array($val['id'], $j['added_tags'])) { echo '<label style="background-color: '.$tag_info[0]->bgcolor.'; color: '.$tag_info[0]->ftcolor.'; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
+							if ( in_array($val['id'], $j['added_tags'])) { echo '<label style="background-color: '.$tag_info[0]->bgcolor.'; color: black; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
 						}
 						echo '<br clear="all" />';
 						echo '<br clear="all" />';
 						echo count($j['removed_tags']).' '.((count($j['removed_tags']) > 1) ? __('tinyissue.tags_removed') : __('tinyissue.tag_removed')).'.';
 						foreach ($j['tag_data'] as $ind => $val ) { 
-							if ( in_array($val['id'], $j['removed_tags'])) { echo '<label style="-color: '.$val['ftcolor'].'; background-color: '.$val['bgcolor'].'; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
+						//2 sept 2021 recherche d'un bogue lié à ftcolor
+							//if ( in_array($val['id'], $j['removed_tags'])) { echo '<label style="-color: '.$val['ftcolor'].'; background-color: '.$val['bgcolor'].'; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
+							if ( in_array($val['id'], $j['removed_tags'])) { echo '<label style="-color: '.@$val['ftcolor'].'; background-color: '.$val['bgcolor'].'; padding: 5px 10px; border-radius: 8px;">'.$val['tag'].'</label>'; } 
 						}
 						echo '<br clear="all" />';
 						echo ' '.date(Config::get('application.my_bugs_app.date_format'), strtotime($activity->attributes['updated_at']));

--- a/app/application/views/tags/index.php
+++ b/app/application/views/tags/index.php
@@ -5,7 +5,11 @@
 <div class="pad">
 
 	<?php foreach($tags as $tag): ?>
-		<?php echo '<a href="' . URL::to('tag/' . $tag->id . '/edit') . '"><label id="tag' . $tag->id . '" class="label" style="' . ($tag->bgcolor ? ' background-color: ' . $tag->bgcolor.';' : '') . ($tag->ftcolor ? ' color: ' . $tag->ftcolor . ';' : '') . '">' . $tag->tag . '</label></a>'; ?><br /><br />
+		<?php 
+		//2 sept 2021 recherche d'un bogue lié à ftcolor
+		//echo '<a href="' . URL::to('tag/' . $tag->id . '/edit') . '"><label id="tag' . $tag->id . '" class="label" style="' . ($tag->bgcolor ? ' background-color: ' . $tag->bgcolor.';' : '') . ($tag->ftcolor ? ' color: ' . $tag->ftcolor . ';' : '') . '">' . $tag->tag . '</label></a>'; 
+		echo '<a href="' . URL::to('tag/' . $tag->id . '/edit') . '"><label id="tag' . $tag->id . '" class="label" style="' . ($tag->bgcolor ? ' background-color: ' . $tag->bgcolor.';' : '') . '">' . $tag->tag . '</label></a>'; 
+		?><br /><br />
 	<?php endforeach; ?>
 	
 	<br />

--- a/app/application/views/user/issues.php
+++ b/app/application/views/user/issues.php
@@ -24,7 +24,8 @@ if(!isset($config_app['PriorityColors'])) { $config_app['PriorityColors'] = arra
 					<?php if(!empty($row->tags)): ?>
 					<div class="tags">
 						<?php foreach($row->tags()->order_by('tag', 'ASC')->get() as $tag): ?>
-						<?php echo '<label class="label" style="'.($tag->bgcolor ? 'background-color: '.$tag->bgcolor . ';' : '').($tag->ftcolor ? 'color: '.$tag->ftcolor . ';' : '').'>' . $tag->tag . '</label>'; ?>
+						//2 sept 2021 recherche d'un bogue lié à ftcolor
+						<?php echo '<label class="label" style="'.($tag->bgcolor ? 'background-color: '.$tag->bgcolor . ';' : '').'>' . $tag->tag . '</label>'; ?>
 						<?php endforeach; ?>
 					</div>
 					<?php endif; ?>


### PR DESCRIPTION
Voici deux étapes de corrections.
Nous supprimons les références à ftcolor dans tous les appels aux tags.