### PR TITLE
Retour des avis de modification aux étiquettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ README.md
 .gitignore~
 install/mysql-structure.php
 install/surete_config-setup.php
+install/config-setup.php_surete
 app/vendor/Trumbowyg/
 app/vendor/Reports/BugsRepConfig.php
 app/storage/reports/*.pdf

--- a/app/application/controllers/project/issue.php
+++ b/app/application/controllers/project/issue.php
@@ -313,16 +313,16 @@ class Project_Issue_Controller extends Base_Controller {
 
 			$Modif = (Input::get('Modif') !== NULL) ? Input::get('Modif') :  false;
 			$Quel = (Input::get('Quel')  !== NULL ) ? Input::get('Quel') : "xyzxyz";
-			$TagNum = Tag::where('tag', '=', $Quel )->first(array('id','tag','ftcolor','bgcolor'));
-			if (!isset($TagNum) || @$TagNum == '' ) { 
-				$Modif = false; $Quel = "xyzxyz"; 
-			} else {
-				//Get tag infos
-				$IssueTagNum = \DB::table('projects_issues_tags')->where('issue_id', '=', $Issue)->where('tag_id', '=', $TagNum->attributes['id'], 'AND' )->first(array('id','tag','ftcolor','bgcolor'));
-			}
+			$TagNum = Tag::where('tag', '=', $Quel )->first(array('id','tag','bgcolor','ftcolor'));
+			if (!isset($TagNum) || @$TagNum == '' ) { $Modif = false; $Quel = "xyzxyz"; }
 
-			//Adding a tag
+
+			/**
+			 * Edit an issue
+			 * Adding a tag
+			 */
 			if ($Modif == 'AddOneTag' ) {
+				$IssueTagNum = \DB::table('projects_issues_tags')->where('issue_id', '=', $Issue)->where('tag_id', '=', $TagNum->attributes['id'], 'AND' )->first(array('id'));
 				$now = date("Y-m-d H:i:s");
 				if ($IssueTagNum == NULL) {
 					\DB::table('projects_issues_tags')->insert(array('id'=>NULL,'issue_id'=>$Issue,'tag_id'=>$TagNum->attributes['id'],'created_at'=>$now,'updated_at'=>$now) );
@@ -332,22 +332,35 @@ class Project_Issue_Controller extends Base_Controller {
 				$Action = NULL;
 				$Msg = __('tinyissue.tag_added');
 				$Show = true;
+				$added_tags = '"added_tags":['.$TagNum->attributes['id'].'],';
+				$removed_tags = '"removed_tags":[],';
 			}
 
-			//Taking a tag off
+			/**
+			 * Edit an issue
+			 * Taking a tag off
+			 */
 			if ($Modif == 'eraseTag') {
+				$IssueTagNum =\DB::table('projects_issues_tags')->where('issue_id','=',$Issue)->where('tag_id','=',$TagNum->id,'AND')->first('id');
 				\DB::table('projects_issues_tags')->delete($IssueTagNum->id);
 				$Action = $Issue;
 				$Modif = true;
 				$Msg = '<span style="color:#F00;">'.__('tinyissue.tag_removed').'</span>';
 				$Show = true;
+				$added_tags = '"added_tags":[],';
+				$removed_tags = '"removed_tags":['.$TagNum->attributes['id'].'],';
 			}
 
-			//* Store and show what just happened  ( or adding or removing )
+
+			/**
+			 * Update database
+			 */
+			if ($Show) { \User\Activity::add(6, 5, $Issue, NULL, '{'.$added_tags.$removed_tags.'"tag_data":{"'.$TagNum->attributes['id'].'":{"id":'.$TagNum->attributes['id'].',"tag":"'.$TagNum->attributes['tag'].'","bgcolor":"'.$TagNum->attributes['bgcolor'].'","ftcolor":"'.$TagNum->attributes['ftcolor'].'"}},"tags_test":"Baboom en poudre"}' ); }
+
+			/**
+			 * Show on screen what just happened
+			 */
 			if (isset($TagNum) && $Quel != "xyzxyz") {
-			 	// Update database
-				if ($Show) { \User\Activity::add(6, 5, $Issue, NULL, '{'.$added_tags.$removed_tags.'"tag_data":{"'.$TagNum->attributes['id'].'":{"id":'.$TagNum->attributes['id'].',"tag":"'.$TagNum->attributes['tag'].'","bgcolor":"'.$TagNum->attributes['bgcolor'].'","ftcolor":"'.$TagNum->attributes['ftcolor'].'"}},"tags_test":"Baboom en poudre"}' ); }
-				//Prepare data to be shown
 				$content .= '<div class="insides"><div class="topbar"><div class="data">';
 				$content .= '<label style="color: '.$TagNum->attributes['ftcolor'].'; background-color: '.$TagNum->attributes['bgcolor'].'; padding: 5px 10px; border-radius: 8px;">';
 				$content .= $TagNum->attributes['tag'].'</label>';

--- a/app/application/controllers/project/issue.php
+++ b/app/application/controllers/project/issue.php
@@ -314,15 +314,15 @@ class Project_Issue_Controller extends Base_Controller {
 			$Modif = (Input::get('Modif') !== NULL) ? Input::get('Modif') :  false;
 			$Quel = (Input::get('Quel')  !== NULL ) ? Input::get('Quel') : "xyzxyz";
 			$TagNum = Tag::where('tag', '=', $Quel )->first(array('id','tag','ftcolor','bgcolor'));
-			if (!isset($TagNum) || @$TagNum == '' ) { $Modif = false; $Quel = "xyzxyz"; }
+			if (!isset($TagNum) || @$TagNum == '' ) { 
+				$Modif = false; $Quel = "xyzxyz"; 
+			} else {
+				//Get tag infos
+				$IssueTagNum = \DB::table('projects_issues_tags')->where('issue_id', '=', $Issue)->where('tag_id', '=', $TagNum->attributes['id'], 'AND' )->first(array('id','tag','ftcolor','bgcolor'));
+			}
 
-
-			/**
-			 * Edit an issue
-			 * Adding a tag
-			 */
+			//Adding a tag
 			if ($Modif == 'AddOneTag' ) {
-				$IssueTagNum = \DB::table('projects_issues_tags')->where('issue_id', '=', $Issue)->where('tag_id', '=', $TagNum->attributes['id'], 'AND' )->first(array('id'));
 				$now = date("Y-m-d H:i:s");
 				if ($IssueTagNum == NULL) {
 					\DB::table('projects_issues_tags')->insert(array('id'=>NULL,'issue_id'=>$Issue,'tag_id'=>$TagNum->attributes['id'],'created_at'=>$now,'updated_at'=>$now) );
@@ -334,31 +334,20 @@ class Project_Issue_Controller extends Base_Controller {
 				$Show = true;
 			}
 
-			/**
-			 * Edit an issue
-			 * Taking a tag off
-			 */
+			//Taking a tag off
 			if ($Modif == 'eraseTag') {
-				$IssueTagNum =\DB::table('projects_issues_tags')->where('issue_id','=',$Issue)->where('tag_id','=',$TagNum->id,'AND')->first('id');
 				\DB::table('projects_issues_tags')->delete($IssueTagNum->id);
 				$Action = $Issue;
 				$Modif = true;
 				$Msg = '<span style="color:#F00;">'.__('tinyissue.tag_removed').'</span>';
 				$Show = true;
-				//2 sept 2021 : désactivé en vue de trouver une solution
-				//$this->Courriel ('Issue', true, Project::current()->id, Project\Issue::current()->id, Auth::user()->id, array('tagsOTE'), array('tinyissue'));
 			}
 
-
-			/**
-			 * Update database
-			 */
-			if ($Show) { \User\Activity::add(6, $Action, $Issue, $TagNum->attributes['id'] ); }
-
-			/**
-			 * Show on screen what just happened
-			 */
+			//* Store and show what just happened  ( or adding or removing )
 			if (isset($TagNum) && $Quel != "xyzxyz") {
+			 	// Update database
+				if ($Show) { \User\Activity::add(6, 5, $Issue, NULL, '{'.$added_tags.$removed_tags.'"tag_data":{"'.$TagNum->attributes['id'].'":{"id":'.$TagNum->attributes['id'].',"tag":"'.$TagNum->attributes['tag'].'","bgcolor":"'.$TagNum->attributes['bgcolor'].'","ftcolor":"'.$TagNum->attributes['ftcolor'].'"}},"tags_test":"Baboom en poudre"}' ); }
+				//Prepare data to be shown
 				$content .= '<div class="insides"><div class="topbar"><div class="data">';
 				$content .= '<label style="color: '.$TagNum->attributes['ftcolor'].'; background-color: '.$TagNum->attributes['bgcolor'].'; padding: 5px 10px; border-radius: 8px;">';
 				$content .= $TagNum->attributes['tag'].'</label>';

--- a/app/application/views/activity/retag-issue.php
+++ b/app/application/views/activity/retag-issue.php
@@ -4,19 +4,18 @@
 	</div>
 
 	<div class="data">
-		<a href="<?php echo $issue->to(); ?>"><?php echo $issue->title; ?></a> <?php echo __('tinyissue.tag_added'); ?>
-		<a href="<?php echo $issue->to(); ?>"><?php echo $issue->title; ?></a> <?php echo __('tinyissue.tag_removed'); ?>
-		<?php if($activity->action_id > 0): ?>
-		<strong><?php echo $assigned->firstname . ' ' . $assigned->lastname; ?></strong>
-		<?php else: ?>
-		<strong><?php echo __('tinyissue.no_one'); ?></strong>
-		<?php endif; ?>
-		<?php echo __('tinyissue.by'); ?>
-		<strong><?php echo $user->firstname . ' ' . $user->lastname; ?></strong>
-
-		<span class="time">
-			<?php echo date(Config::get('application.my_bugs_app.date_format'), strtotime($activity->created_at)); ?>
-		</span>
+		<?php 
+			echo '<a href="'.$issue->to().'">'.$issue->title.'</a>'.__('tinyissue.tag_added');
+			echo '<a href="'.$issue->to().'">'.$issue->title.'</a>'.__('tinyissue.tag_removed');
+			echo '<strong>';
+			echo ($activity->action_id > 0) ? $assigned->firstname . ' ' . $assigned->lastname : __('tinyissue.no_one'); 
+			echo '</strong>';
+			echo __('tinyissue.by'); 
+			echo '<strong>'.$user->firstname . ' ' . $user->lastname.'</strong>';
+			echo '<span class="time">';
+			echo date(Config::get('application.my_bugs_app.date_format'), strtotime($activity->created_at));
+			echo '</span>';
+		 ?>
 	</div>
 
 	<div class="clr"></div>

--- a/app/application/views/activity/update-issue-tags.php
+++ b/app/application/views/activity/update-issue-tags.php
@@ -8,10 +8,12 @@
 			<?php 
 				if($tag_counts['added'] > 0) {
 					foreach($tag_diff['added_tags'] as $tag) { 
-						echo '<label class="label notice">' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+						echo '<label class="label notice" style="color:'.$tag_diff['tag_data'][$tag]['ftcolor'].';background-color:'.$tag_diff['tag_data'][$tag]['bgcolor'].';">' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
 					} 
-					echo __($tag_counts['added'] > 1 ? 'tinyissue.tags_added' : 'tinyissue.tag_added'); 
+					echo __($tag_counts['added'] > 1 ? 'tinyissue.tags_added' : 'tinyissue.tag_added');
+					echo ' '; 
 					echo __('tinyissue.in'); 
+					echo ' '; 
 					echo '<a href="'.$issue->to().'">'.$issue->title.'</a>';
 					echo __('tinyissue.by'); 
 					echo '<strong>'.$user->firstname . ' ' . $user->lastname.'</strong>';
@@ -21,10 +23,12 @@
 			
 			if($tag_counts['removed'] > 0) {
 				foreach($tag_diff['removed_tags'] as $tag) { 
-					echo '<label class="label notice">' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
+					echo '<label class="label notice" style="color:'.$tag_diff['tag_data'][$tag]['ftcolor'].';background-color:'.$tag_diff['tag_data'][$tag]['bgcolor'].';">' . $tag_diff['tag_data'][$tag]['tag'] . '</label>'; 
 				}
 				echo __($tag_counts['removed'] > 1 ? 'tinyissue.tags_removed' : 'tinyissue.tag_removed'); 
+					echo ' '; 
 				echo __('tinyissue.in'); 
+					echo ' '; 
 				echo '<a href="'.$issue->to().'">'.$issue->title.'</a>';
 				echo __('tinyissue.by');
 				echo '<strong>'.$user->firstname . ' ' . $user->lastname.'</strong>';


### PR DESCRIPTION
Les avis de modification aux étiquettes rattachées à un billet fonctionnaient plus ou moins bien.  Les voici de retour avec la colorisation adéquate des étiquettes dans le panneau de contrôle et dans les détails historique d'un billet.